### PR TITLE
Fix path for deb build.

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,1 +1,1 @@
-build/redsea /usr/bin
+src/redsea /usr/bin


### PR DESCRIPTION
The binary after being build ends up in src/redsea and not build/redsea:

````
dpkg-buildpackage -us -uc
[...]
make[1]: Leaving directory '/home/sdr/test/redsea'
   dh_install
dh_install: warning: Cannot find (any matches for) "build/redsea" (tried in ., debian/tmp)

dh_install: warning: redsea missing files: build/redsea
dh_install: error: missing files, aborting
make: *** [debian/rules:3: binary] Error 255
dpkg-buildpackage: error: debian/rules binary subprocess returned exit status 2
````

This pull request fixes this and debs are now generated:
````
make[1]: Leaving directory '/home/sdr/test/redsea'
   dh_install
   dh_installdocs
   dh_installchangelogs
   dh_perl
   dh_link
   dh_strip_nondeterminism
   dh_compress
   dh_fixperms
   dh_missing
   dh_dwz
   dh_strip
   dh_makeshlibs
   dh_shlibdeps
dpkg-shlibdeps: warning: diversions involved - output may be incorrect
 diversion by libc6 from: /lib/ld-linux-aarch64.so.1
dpkg-shlibdeps: warning: diversions involved - output may be incorrect
 diversion by libc6 to: /lib/ld-linux-aarch64.so.1.usr-is-merged
   dh_installdeb
   dh_gencontrol
   dh_md5sums
   dh_builddeb
dpkg-deb: building package 'redsea' in '../redsea_0.21_arm64.deb'.
dpkg-deb: building package 'redsea-dbgsym' in '../redsea-dbgsym_0.21_arm64.deb'.
 dpkg-genbuildinfo -O../redsea_0.21_arm64.buildinfo
 dpkg-genchanges -O../redsea_0.21_arm64.changes
dpkg-genchanges: info: including full source code in upload
 dpkg-source --after-build .
dpkg-buildpackage: info: full upload; Debian-native package (full source is included)
````